### PR TITLE
Use forceSSL flag

### DIFF
--- a/analytics_lib.js
+++ b/analytics_lib.js
@@ -18,6 +18,7 @@ m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
 })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
 
 ga('create', analyticsTrackingCode, 'auto');
+ga('set', 'forceSSL', true);
 ga('send', 'pageview');
 
 function handleOutboundLinkClicks(href) {


### PR DESCRIPTION
This uses the `forceSSL` setting to ensure that both Google Analytics pings are always sent over HTTPS.

(GA makes two pings: 1) to download analytics.js, 2) to do the data reporting. Using `https://` in the snippet code, which is already done, handles (1), and `forceSSL` handles (2).)
